### PR TITLE
iOS BLE advertising

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,7 +7,7 @@ const { Bridge } = NativeModules;
 class App extends Component {
   constructor() {
     super();
-    this.state = {result: null, devices: []};
+    this.state = {result: null, devices: [], peripheralState: null};
   }
 
   componentDidMount() {
@@ -30,6 +30,10 @@ class App extends Component {
         this.handleDevice(device)
       })
 
+      emitter.addListener('peripheralstate', (peripheralState) => { 
+        this.handlePeripheralState(peripheralState)
+      })
+
       const module = NativeModules.Bridge
       console.log(`Bridge module: ${module}`)
       // module.startDiscovery()
@@ -45,12 +49,22 @@ class App extends Component {
     }))
   }
 
+  handlePeripheralState = (peripheralState) => {
+    console.log('got peripheral state: ' + peripheralState) 
+    this.setState(prevState => ({
+      peripheralState: peripheralState
+    }))
+  }
+
   render() {
     return (
       <View style={styles.container}>
         <Text style={styles.text}>CoEpi</Text>
         <Text>
           {this.state.result === null ? 'Loading…' : this.state.result}
+        </Text>
+        <Text>
+          {this.state.peripheralState === null ? 'Will show peripheral state here if using as peripheral' : this.state.peripheralState}
         </Text>
 
         <FlatList 

--- a/app/app.js
+++ b/app/app.js
@@ -32,7 +32,9 @@ class App extends Component {
 
       const module = NativeModules.Bridge
       console.log(`Bridge module: ${module}`)
-      module.startDiscovery()
+      // module.startDiscovery()
+
+      module.startAdvertising()
     }
   }
 

--- a/ios/Bridge.m
+++ b/ios/Bridge.m
@@ -1,5 +1,6 @@
 #import "React/RCTBridgeModule.h"
 
 @interface RCT_EXTERN_MODULE(Bridge, NSObject)
-  RCT_EXTERN_METHOD(startDiscovery)
+    RCT_EXTERN_METHOD(startDiscovery)
+    RCT_EXTERN_METHOD(startAdvertising)
 @end

--- a/ios/Bridge.m
+++ b/ios/Bridge.m
@@ -1,6 +1,7 @@
 #import "React/RCTBridgeModule.h"
 
 @interface RCT_EXTERN_MODULE(Bridge, NSObject)
-    RCT_EXTERN_METHOD(startDiscovery)
+// FIXME "No bundle URL present" if both are enabled.
+//    RCT_EXTERN_METHOD(startDiscovery)
     RCT_EXTERN_METHOD(startAdvertising)
 @end

--- a/ios/Bridge.swift
+++ b/ios/Bridge.swift
@@ -5,7 +5,7 @@ import CoreBluetooth
 class Bridge: RCTEventEmitter {
 
     @objc override func supportedEvents() -> [String]! {
-        return ["device"]
+        return ["device", "peripheralstate"]
     }
 
     var discovery: BLEDiscovery?
@@ -20,9 +20,10 @@ class Bridge: RCTEventEmitter {
 
     @objc
     func startAdvertising() {
-        peripheral = Peripheral()
+        peripheral = Peripheral(onStateChange: { [weak self] state in
+            self?.sendEvent(withName: "peripheralstate", body: state)
+        })
     }
-
 
     @objc
     override static func requiresMainQueueSetup() -> Bool {

--- a/ios/Bridge.swift
+++ b/ios/Bridge.swift
@@ -8,14 +8,21 @@ class Bridge: RCTEventEmitter {
         return ["device"]
     }
 
-    var ble: BLEDiscovery?
+    var discovery: BLEDiscovery?
+    var peripheral: Peripheral?
 
     @objc
     func startDiscovery() {
-        ble = BLEDiscovery(onDiscovered: { [weak self] peripheral in
+        discovery = BLEDiscovery(onDiscovered: { [weak self] peripheral in
             self?.sendEvent(withName: "device", body: peripheral.toBridgeObject())
         })
     }
+
+    @objc
+    func startAdvertising() {
+        peripheral = Peripheral()
+    }
+
 
     @objc
     override static func requiresMainQueueSetup() -> Bool {

--- a/ios/CoEpi.xcodeproj/project.pbxproj
+++ b/ios/CoEpi.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		849E003C24152F3E007DB872 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E003B24152F3E007DB872 /* Bridge.swift */; };
 		849E003E24152F8D007DB872 /* Bridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 849E003D24152F8D007DB872 /* Bridge.m */; };
 		84A05AA1241551A500843354 /* BLEDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A05AA0241551A500843354 /* BLEDiscovery.swift */; };
+		84A64ECD2419785B003BEC25 /* Peripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A64ECC2419785B003BEC25 /* Peripheral.swift */; };
 		8D4826396D6ED806B1AAB240 /* libPods-CoEpi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37DE2CF01D1C0EF799E7168C /* libPods-CoEpi.a */; };
 		E64FBE63A6DC4B90A79EB154 /* libPods-CoEpi-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA95D893CE66627576115A1F /* libPods-CoEpi-tvOS.a */; };
 /* End PBXBuildFile section */
@@ -64,6 +65,7 @@
 		849E003B24152F3E007DB872 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
 		849E003D24152F8D007DB872 /* Bridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Bridge.m; sourceTree = "<group>"; };
 		84A05AA0241551A500843354 /* BLEDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEDiscovery.swift; sourceTree = "<group>"; };
+		84A64ECC2419785B003BEC25 /* Peripheral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peripheral.swift; sourceTree = "<group>"; };
 		9AE11219F5F11E1967C28546 /* Pods-CoEpi.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpi.debug.xcconfig"; path = "Target Support Files/Pods-CoEpi/Pods-CoEpi.debug.xcconfig"; sourceTree = "<group>"; };
 		9BC35E1A6ECA77DF53A54AD5 /* Pods-CoEpi-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpi-tvOS.release.xcconfig"; path = "Target Support Files/Pods-CoEpi-tvOS/Pods-CoEpi-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		9E04946EADA216F7C3A9A69D /* Pods-CoEpiTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpiTests.release.xcconfig"; path = "Target Support Files/Pods-CoEpiTests/Pods-CoEpiTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				849E003A24152F3E007DB872 /* CoEpi-Bridging-Header.h */,
 				849E003D24152F8D007DB872 /* Bridge.m */,
 				84A05AA0241551A500843354 /* BLEDiscovery.swift */,
+				84A64ECC2419785B003BEC25 /* Peripheral.swift */,
 			);
 			name = CoEpi;
 			sourceTree = "<group>";
@@ -300,6 +303,8 @@
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;
+						DevelopmentTeam = 37QAPDY2PR;
+						ProvisioningStyle = Manual;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
@@ -543,6 +548,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				849E003E24152F8D007DB872 /* Bridge.m in Sources */,
+				84A64ECD2419785B003BEC25 /* Peripheral.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				84A05AA1241551A500843354 /* BLEDiscovery.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
@@ -601,6 +607,8 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 37QAPDY2PR;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -615,6 +623,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CoEpi.app/CoEpi";
 			};
 			name = Debug;
@@ -625,7 +635,9 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = 37QAPDY2PR;
 				INFOPLIST_FILE = CoEpiTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -636,6 +648,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CoEpi.app/CoEpi";
 			};
 			name = Release;
@@ -646,8 +660,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
+				DEVELOPMENT_TEAM = 37QAPDY2PR;
 				INFOPLIST_FILE = CoEpi/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -657,6 +673,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = CoEpi;
+				PROVISIONING_PROFILE_SPECIFIER = coepi;
 				SWIFT_OBJC_BRIDGING_HEADER = "CoEpi-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -670,7 +687,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 37QAPDY2PR;
 				INFOPLIST_FILE = CoEpi/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -680,6 +699,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = CoEpi;
+				PROVISIONING_PROFILE_SPECIFIER = coepi;
 				SWIFT_OBJC_BRIDGING_HEADER = "CoEpi-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -696,7 +716,10 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "CoEpi-tvOS/Info.plist";
@@ -708,6 +731,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.CoEpi-tvOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
@@ -724,8 +748,11 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "CoEpi-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -736,6 +763,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.CoEpi-tvOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;

--- a/ios/CoEpi.xcodeproj/xcshareddata/xcschemes/CoEpi.xcscheme
+++ b/ios/CoEpi.xcodeproj/xcshareddata/xcschemes/CoEpi.xcscheme
@@ -55,6 +55,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "CoEpi.app"
+            BlueprintName = "CoEpi"
+            ReferencedContainer = "container:CoEpi.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -67,17 +76,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "CoEpi.app"
-            BlueprintName = "CoEpi"
-            ReferencedContainer = "container:CoEpi.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -99,8 +97,6 @@
             ReferencedContainer = "container:CoEpi.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ios/CoEpi/Info.plist
+++ b/ios/CoEpi/Info.plist
@@ -55,5 +55,10 @@
 	<false/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>TODO explain user how the app uses bluetooth</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-central</string>
+		<string>bluetooth-peripheral</string>
+	</array>
 </dict>
 </plist>

--- a/ios/Peripheral.swift
+++ b/ios/Peripheral.swift
@@ -2,13 +2,16 @@ import Foundation
 import CoreBluetooth
 
 class Peripheral: NSObject {
+    private let onStateChange: ((String) -> Void)?
 
     private var peripheralManager: CBPeripheralManager!
 
     private let serviceUuid = CBUUID(nsuuid: UUID(uuidString: "BC908F39-52DB-416F-A97E-6EAC29F59CA8")!)
     private let characteristicUuid = CBUUID(nsuuid: UUID(uuidString: "2ac35b0b-00b5-4af2-a50e-8412bcb94285")!)
 
-    override init() {
+    init(onStateChange: @escaping ((String) -> Void)) {
+        self.onStateChange = onStateChange
+
         super.init()
         peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
     }
@@ -49,21 +52,25 @@ extension Peripheral: CBPeripheralManagerDelegate {
     func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
         switch peripheral.state {
         case .unknown:
-            print("Peripheral state: unknown")
+            report(state: "unknown")
         case .unsupported:
-            print("Peripheral state: unsupported")
+            report(state: "unsupported")
         case .unauthorized:
-            print("Peripheral state: unauthorized")
+            report(state: "unauthorized")
         case .resetting:
-            print("Peripheral state: resetting")
+            report(state: "resetting")
         case .poweredOff:
-            print("Peripheral state: poweredOff")
+            report(state: "poweredOff")
         case .poweredOn:
-            print("Peripheral state: poweredOn")
+            report(state: "poweredOn")
             startAdvertising()
         @unknown default:
             print("Peripheral state: unknown")
         }
+    }
+
+    private func report(state: String) {
+        onStateChange?("Peripheral state: \(state)")
     }
 
     func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {

--- a/ios/Peripheral.swift
+++ b/ios/Peripheral.swift
@@ -1,0 +1,76 @@
+import Foundation
+import CoreBluetooth
+
+class Peripheral: NSObject {
+
+    private var peripheralManager: CBPeripheralManager!
+
+    private let serviceUuid = CBUUID(nsuuid: UUID(uuidString: "BC908F39-52DB-416F-A97E-6EAC29F59CA8")!)
+    private let characteristicUuid = CBUUID(nsuuid: UUID(uuidString: "2ac35b0b-00b5-4af2-a50e-8412bcb94285")!)
+
+    override init() {
+        super.init()
+        peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
+    }
+
+    private func startAdvertising() {
+        let service = createService()
+        peripheralManager.add(service)
+
+        print("Will start advertising")
+
+        peripheralManager.startAdvertising([
+            // NOTE/TODO this identifier is supposed to show directly in discovery. It doesn't. Service is listed in iPhone peripheral.
+            CBAdvertisementDataLocalNameKey : "BLEPeripheralApp",
+
+            CBAdvertisementDataServiceUUIDsKey : [serviceUuid]
+        ])
+
+        print("Started advertising")
+    }
+
+    private func createService() -> CBMutableService {
+        let service = CBMutableService(type: serviceUuid, primary: true)
+
+        let characteristic = CBMutableCharacteristic(
+            type: characteristicUuid,
+            properties: [.read],
+            value: "AD34E".data(using: .utf8),
+            permissions: [.readable]
+        )
+        service.characteristics = [characteristic]
+
+        return service
+    }
+}
+
+extension Peripheral: CBPeripheralManagerDelegate {
+
+    func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        switch peripheral.state {
+        case .unknown:
+            print("Peripheral state: unknown")
+        case .unsupported:
+            print("Peripheral state: unsupported")
+        case .unauthorized:
+            print("Peripheral state: unauthorized")
+        case .resetting:
+            print("Peripheral state: resetting")
+        case .poweredOff:
+            print("Peripheral state: poweredOff")
+        case .poweredOn:
+            print("Peripheral state: poweredOn")
+            startAdvertising()
+        @unknown default:
+            print("Peripheral state: unknown")
+        }
+    }
+
+    func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
+        if error == nil {
+            NSLog("Advertising ok")
+        } else {
+            NSLog("Advertising error: \(String(describing: error))")
+        }
+    }
+}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -250,7 +250,7 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  trunk:
+  https://github.com/CocoaPods/Specs.git:
     - boost-for-react-native
 
 EXTERNAL SOURCES:


### PR DESCRIPTION
iOS advertising using core bluetooth, proof of concept. 

For now it contains only a dummy read-only characteristic. 

I was able to see the service using a BLE client app. It appears however listed under the iPhone, not as a standalone peripheral. It's supposed to appear as standalone. Maybe this behavior has changed in recent iOS versions, have to investigate that.

The uuids of the service and characteristic are [here](https://github.com/Co-Epi/mobile-app/commit/9dec16033699568193e1397c74c3b1fccc0afabf#diff-e7f575a4b56951cb3b8900863f7cc4daR8-R9).

Added background modes for peripheral and central. It appears to work at least shortly after the app is put in the background. More testing needed.