### PR TITLE
Add usage description for iOS pre 13

### DIFF
--- a/ios/CoEpi/Info.plist
+++ b/ios/CoEpi/Info.plist
@@ -55,6 +55,8 @@
 	<false/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>TODO explain user how the app uses bluetooth</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>TODO explain user how the app uses bluetooth</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>


### PR DESCRIPTION
iOS pre 13 requires a different usage description key.