### PR TITLE
Integrate covid19risk

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,7 +7,7 @@ const { Bridge } = NativeModules;
 class App extends Component {
   constructor() {
     super();
-    this.state = {result: null, devices: [], peripheralState: null};
+    this.state = {result: null, devices: [], peripheralState: null, contacts: []};
   }
 
   componentDidMount() {
@@ -35,7 +35,7 @@ class App extends Component {
       })
 
       emitter.addListener('contact', (contact) => { 
-        this.handlePeripheralState(contact)
+        this.handleContact(contact)
       })
 
       const module = NativeModules.Bridge
@@ -48,10 +48,10 @@ class App extends Component {
   }
 
   handleDevice = (device) => {
-    console.log('got device: ' + device) 
-    this.setState(prevState => ({
-      devices: [...prevState.devices, device]
-    }))
+    // console.log('got device: ' + device) 
+    // this.setState(prevState => ({
+    //   devices: [...prevState.devices, device]
+    // }))
   }
 
   handlePeripheralState = (peripheralState) => {
@@ -63,6 +63,9 @@ class App extends Component {
 
   handleContact = (contact) => {
     console.log('got contact: ' + contact) 
+    this.setState(prevState => ({
+      contacts: [...prevState.contacts, contact]
+    }))
     // TODO display
   }
 
@@ -76,12 +79,16 @@ class App extends Component {
         <Text>
           {this.state.peripheralState === null ? 'Will show peripheral state here if using as peripheral' : this.state.peripheralState}
         </Text>
-
         <FlatList 
+          keyExtractor={(item) => item.identifier} 
+          renderItem={({item}) => <Text style={styles.item}>{`${item.identifier}`}</Text>}
+          data={this.state.contacts} 
+        />
+        {/* <FlatList 
           keyExtractor={(item) => item.address} 
           renderItem={({item}) => <Text style={styles.item}>{`${item.address} ${item.name}`}</Text>}
           data={this.state.devices} 
-        />
+        /> */}
       </View>
     );
   }

--- a/app/app.js
+++ b/app/app.js
@@ -34,6 +34,10 @@ class App extends Component {
         this.handlePeripheralState(peripheralState)
       })
 
+      emitter.addListener('contact', (contact) => { 
+        this.handlePeripheralState(contact)
+      })
+
       const module = NativeModules.Bridge
       console.log(`Bridge module: ${module}`)
       // module.startDiscovery()
@@ -54,6 +58,11 @@ class App extends Component {
     this.setState(prevState => ({
       peripheralState: peripheralState
     }))
+  }
+
+  handleContact = (contact) => {
+    console.log('got contact: ' + contact) 
+    // TODO display
   }
 
   render() {

--- a/app/app.js
+++ b/app/app.js
@@ -43,6 +43,7 @@ class App extends Component {
       // module.startDiscovery()
 
       module.startAdvertising()
+      module.startDiscovery()
     }
   }
 

--- a/ios/BLEDiscovery.swift
+++ b/ios/BLEDiscovery.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreBluetooth
+import os.log
 
 class BLEDiscovery: NSObject, CBCentralManagerDelegate {
     private let onDiscovered: ((CBPeripheral) -> Void)?
@@ -12,23 +13,22 @@ class BLEDiscovery: NSObject, CBCentralManagerDelegate {
     }
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
-
         switch central.state {
         case .unknown:
-            print("BLE unknown")
+            os_log("BLE unknown", log: bluetoothLog)
         case .resetting:
-            print("BLE resetting")
+            os_log("BLE resetting", log: bluetoothLog)
         case .unsupported:
-            print("BLE unsupported")
+            os_log("BLE unsupported", log: bluetoothLog)
         case .unauthorized:
-            print("BLE unauthorized")
+            os_log("BLE unauthorized", log: bluetoothLog)
         case .poweredOff:
-            print("BLE poweredOff")
+            os_log("BLE poweredOff", log: bluetoothLog)
         case .poweredOn:
-            print("BLE poweredOn")
+            os_log("BLE poweredOn", log: bluetoothLog)
             centralManager.scanForPeripherals(withServices: nil)
         @unknown default:
-            print("BLE default")
+            os_log("BLE default", log: bluetoothLog)
         }
     }
 

--- a/ios/Bridge.m
+++ b/ios/Bridge.m
@@ -1,7 +1,6 @@
 #import "React/RCTBridgeModule.h"
 
 @interface RCT_EXTERN_MODULE(Bridge, NSObject)
-// FIXME "No bundle URL present" if both are enabled.
-//    RCT_EXTERN_METHOD(startDiscovery)
+    RCT_EXTERN_METHOD(startDiscovery)
     RCT_EXTERN_METHOD(startAdvertising)
 @end

--- a/ios/Bridge.swift
+++ b/ios/Bridge.swift
@@ -62,7 +62,7 @@ extension CBPeripheral {
 extension Contact {
     func toBridgeObject() -> [String : AnyObject] {
         [
-            "identifier": identifier as AnyObject,
+            "identifier": identifier.uuidString as AnyObject,
             "timestamp": timestamp as AnyObject,
             "isPotentiallyInfectious": isPotentiallyInfectious as AnyObject
         ]

--- a/ios/Bridge.swift
+++ b/ios/Bridge.swift
@@ -8,14 +8,12 @@ class Bridge: RCTEventEmitter {
         return ["device", "peripheralstate", "contact"]
     }
 
-    var discovery: BLEDiscovery?
+    var discovery: Central?
     var peripheral: Peripheral?
 
     @objc
     func startDiscovery() {
-        discovery = BLEDiscovery(onDiscovered: { [weak self] peripheral in
-            self?.sendEvent(withName: "device", body: peripheral.toBridgeObject())
-        })
+        discovery = Central(delegate: self)
     }
 
     @objc
@@ -29,13 +27,25 @@ class Bridge: RCTEventEmitter {
     }
 }
 
+extension Bridge: CentralDelegate {
+
+    func onDiscovered(peripheral: CBPeripheral) {
+        sendEvent(withName: "device", body: peripheral.toBridgeObject())
+    }
+
+    func onCentralContact(_ contact: Contact) {
+        sendEvent(withName: "contact", body: contact.toBridgeObject())
+    }
+}
+
+
 extension Bridge: PeripheralDelegate {
 
     func onPeripheralStateChange(description: String) {
         sendEvent(withName: "peripheralstate", body: description)
     }
 
-    func onNewContact(_ contact: Contact) {
+    func onPeripheralContact(_ contact: Contact) {
         sendEvent(withName: "contact", body: contact.toBridgeObject())
     }
 }

--- a/ios/Central.swift
+++ b/ios/Central.swift
@@ -1,0 +1,483 @@
+import Foundation
+import CoreBluetooth
+import os.log
+
+protocol CentralDelegate: class {
+    func onDiscovered(peripheral: CBPeripheral)
+    func onCentralContact(_ contact: Contact)
+}
+
+class Central: NSObject {
+    private weak var delegate: CentralDelegate?
+
+    private var centralManager: CBCentralManager!
+
+    private var peripheral: CBPeripheral!
+
+    private var discoveredPeripherals = Set<CBPeripheral>()
+
+    private var discoveringServicesPeripheralIdentifiers = Set<UUID>()
+    private var readingConfigurationCharacteristics = Set<CBCharacteristic>()
+
+    private var peripheralsToReadConfigurationsFrom = Set<CBPeripheral>()
+    private var peripheralsToConnect: Set<CBPeripheral> {
+        Set(peripheralsToReadConfigurationsFrom)
+    }
+
+    private var connectingPeripheralIdentifiers = Set<UUID>()
+    private var connectedPeripheralIdentifiers = Set<UUID>()
+
+    private var connectingConnectedPeripheralIdentifiers: Set<UUID> {
+        connectingPeripheralIdentifiers.union(connectedPeripheralIdentifiers)
+    }
+
+    #if os(watchOS)
+    private let maxNumberOfConcurrentPeripheralConnections = 2
+    #else
+    private let maxNumberOfConcurrentPeripheralConnections = 5
+    #endif
+
+    private var connectingTimeoutTimersForPeripheralIdentifiers = [UUID : Timer]()
+    public let label = UUID().uuidString
+    lazy private var dispatchQueue: DispatchQueue =
+        DispatchQueue(label: label, qos: .userInteractive)
+
+    init(delegate: CentralDelegate) {
+        self.delegate = delegate
+        super.init()
+        centralManager = CBCentralManager(delegate: self, queue: nil)
+    }
+
+    private func startScan() {
+        let services = servicesToScan()
+        centralManager.scanForPeripherals(
+            withServices: services,
+            options: [
+                CBCentralManagerScanOptionAllowDuplicatesKey : NSNumber(booleanLiteral: true)
+            ]
+        )
+        os_log("Central manager scanning for peripherals with services=%@", log: bluetoothLog, services ?? [])
+    }
+
+    private func servicesToScan() -> [CBUUID]? {
+        #if targetEnvironment(macCatalyst)
+        // CoreBluetooth on macCatalyst doesn't discover services of iOS apps
+        // running in the background. Therefore we scan for everything.
+        return nil
+        #else
+        return [CBUUID(string: Uuids.service.uuidString)]
+        #endif
+    }
+
+    private func connectPeripheralsIfNeeded() {
+        guard
+            peripheralsToConnect.count > 0,
+            connectingConnectedPeripheralIdentifiers.count < maxNumberOfConcurrentPeripheralConnections
+            else { return }
+
+        let disconnectedPeripherals = self.peripheralsToConnect.filter {
+            $0.state == .disconnected || $0.state == .disconnecting
+        }
+        disconnectedPeripherals.prefix(
+            maxNumberOfConcurrentPeripheralConnections - connectingConnectedPeripheralIdentifiers.count
+        ).forEach {
+            connectIfNeeded(peripheral: $0)
+        }
+    }
+
+    private func connectIfNeeded(peripheral: CBPeripheral) {
+        if peripheral.state != .connected && peripheral.state != .connecting {
+            centralManager?.connect(peripheral, options: nil)
+
+            os_log(
+                "Central manager connecting peripheral (uuid: %@ name: %@)",
+                log: bluetoothLog,
+                peripheral.identifier.description,
+                peripheral.name ?? ""
+            )
+
+            setupConnectingTimeoutTimer(for: peripheral)
+            connectingPeripheralIdentifiers.insert(peripheral.identifier)
+
+        } else {
+            centralManager(centralManager, didConnect: peripheral)
+        }
+    }
+
+    private func setupConnectingTimeoutTimer(for peripheral: CBPeripheral) {
+        let timer = Timer.init(
+            timeInterval: .peripheralConnectingTimeout,
+            target: self,
+            selector: #selector(connectingTimeoutTimerFired(timer:)),
+            userInfo: ["peripheral" : peripheral],
+            repeats: false
+        )
+        timer.tolerance = 0.5
+        RunLoop.main.add(timer, forMode: .common)
+        connectingTimeoutTimersForPeripheralIdentifiers[peripheral.identifier]?.invalidate()
+        connectingTimeoutTimersForPeripheralIdentifiers[peripheral.identifier] = timer
+    }
+
+    @objc private func connectingTimeoutTimerFired(timer: Timer) {
+        let userInfo = timer.userInfo
+
+        self.dispatchQueue.async { [weak self] in
+            guard
+                let self = self,
+                let userInfo = userInfo as? [AnyHashable : Any],
+                let peripheral = userInfo["peripheral"] as? CBPeripheral
+                else { return }
+
+            if peripheral.state != .connected {
+                os_log(
+                    "Connecting did time out for peripheral (uuid=%@ name='%@')",
+                    log: bluetoothLog,
+                    peripheral.identifier.description,
+                    peripheral.name ?? ""
+                )
+                self.flushPeripheral(peripheral)
+            }
+        }
+    }
+
+    private func flushPeripheral(_ peripheral: CBPeripheral) {
+        peripheralsToReadConfigurationsFrom.remove(peripheral)
+        discoveredPeripherals.remove(peripheral)
+        cancelConnectionIfNeeded(for: peripheral)
+    }
+
+    private func cancelConnectionIfNeeded(for peripheral: CBPeripheral) {
+        connectingTimeoutTimersForPeripheralIdentifiers[peripheral.identifier]?.invalidate()
+        connectingTimeoutTimersForPeripheralIdentifiers[peripheral.identifier] = nil
+
+        if peripheral.state == .connecting || peripheral.state == .connected {
+            centralManager?.cancelPeripheralConnection(peripheral)
+            os_log(
+                "Central manager cancelled peripheral (uuid=%@ name='%@') connection",
+                log: bluetoothLog,
+                peripheral.identifier.description,
+                peripheral.name ?? ""
+            )
+        }
+        peripheral.delegate = nil
+
+        connectingPeripheralIdentifiers.remove(peripheral.identifier)
+        connectedPeripheralIdentifiers.remove(peripheral.identifier)
+
+        discoveringServicesPeripheralIdentifiers.remove(peripheral.identifier)
+
+        peripheral.services?.forEach {
+            $0.characteristics?.forEach {
+                readingConfigurationCharacteristics.remove($0)
+            }
+        }
+
+        connectPeripheralsIfNeeded()
+    }
+
+}
+
+extension Central: CBCentralManagerDelegate {
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        os_log("Central manager did update state: %d", log: bluetoothLog, central.state.rawValue)
+        if central.state == .poweredOn {
+            startScan()
+            centralManager.scanForPeripherals(withServices: nil)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
+                        advertisementData: [String: Any], rssi RSSI: NSNumber) {
+
+        delegate?.onDiscovered(peripheral: peripheral)
+
+        self.peripheral = peripheral
+//        centralManager.stopScan()
+
+        delegate?.onDiscovered(peripheral: peripheral)
+
+        os_log("advertisementData: %@", log: bluetoothLog, advertisementData)
+
+        if !discoveredPeripherals.contains(peripheral) {
+            os_log(
+                "Central manager did discover new peripheral (uuid: %@ name: %@) RSSI: %d",
+                log: bluetoothLog,
+                peripheral.identifier.description,
+                peripheral.name ?? "",
+                RSSI.intValue
+            )
+            peripheralsToReadConfigurationsFrom.insert(peripheral)
+        }
+
+        discoveredPeripherals.insert(peripheral)
+        connectPeripheralsIfNeeded()
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        os_log(
+            "Central manager did connect peripheral (uuid: %@ name: %@)",
+            log: bluetoothLog,
+            peripheral.identifier.description,
+            peripheral.name ?? ""
+        )
+
+        connectingTimeoutTimersForPeripheralIdentifiers[peripheral.identifier]?.invalidate()
+        connectingTimeoutTimersForPeripheralIdentifiers[peripheral.identifier] = nil
+        connectingPeripheralIdentifiers.remove(peripheral.identifier)
+
+        // Bug workaround: Ignore duplicate connect messages from CoreBluetooth
+        guard
+            !connectedPeripheralIdentifiers.contains(peripheral.identifier)
+            else { return }
+
+        connectedPeripheralIdentifiers.insert(peripheral.identifier)
+
+        discoverServices(for: peripheral)
+    }
+
+    private func discoverServices(for peripheral: CBPeripheral) {
+        guard
+            !discoveringServicesPeripheralIdentifiers.contains(peripheral.identifier)
+            else { return }
+
+        discoveringServicesPeripheralIdentifiers.insert(peripheral.identifier)
+        peripheral.delegate = self
+
+        if peripheral.services == nil {
+            let services = [CBUUID(string: Uuids.service.uuidString)]
+            peripheral.discoverServices(services)
+
+            os_log(
+                "Central manager periferal: (uuid: %@ name: %@) discovering services: %@",
+                log: bluetoothLog,
+                peripheral.identifier.description,
+                peripheral.name ?? "",
+                services
+            )
+        } else {
+            peripheralShared(peripheral, didDiscoverServices: nil)
+        }
+    }
+
+    private func addNewContactEvent(with identifier: UUID) {
+        delegate?.onCentralContact(Contact(
+            identifier: identifier,
+            timestamp: Date(),
+            // TODO preference, from React Native
+            isPotentiallyInfectious: true
+        ))
+    }
+
+    private func peripheralShared(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+
+        discoveringServicesPeripheralIdentifiers.remove(peripheral.identifier)
+
+        guard error == nil else {
+            cancelConnectionIfNeeded(for: peripheral)
+            return
+        }
+
+        guard let services = peripheral.services, services.count > 0 else {
+            peripheralsToReadConfigurationsFrom.remove(peripheral)
+            cancelConnectionIfNeeded(for: peripheral)
+            return
+        }
+
+        let servicesWithCharacteristicsToDiscover = services.filter {
+            $0.characteristics == nil
+        }
+        if servicesWithCharacteristicsToDiscover.count == 0 {
+            startTransfers(for: peripheral)
+
+        } else {
+            servicesWithCharacteristicsToDiscover.forEach { service in
+                let characteristics = [ CBUUID(string: Uuids.characteristic.uuidString) ]
+                peripheral.discoverCharacteristics(characteristics, for: service)
+
+                os_log(
+                    "Peripheral (uuid: %@ name: %@) discovering characteristics=%@ for service: %@",
+                    log: bluetoothLog,
+                    peripheral.identifier.description,
+                    peripheral.name ?? "",
+                    characteristics.description,
+                    service.description
+                )
+            }
+        }
+    }
+
+}
+
+
+extension Central: CBPeripheralDelegate {
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        guard let services = peripheral.services else { return }
+
+        for service in services {
+          os_log("service: %@", log: bluetoothLog, service)
+        }
+
+        peripheralShared(peripheral, didDiscoverServices: error)
+    }
+
+    func peripheral(
+        _ peripheral: CBPeripheral,
+        didDiscoverCharacteristicsFor service: CBService,
+        error: Error?
+    ) {
+        if let error = error {
+            os_log(
+                "Peripheral (uuid: %@ name: %@) did discover characteristics for service: %@ error: %@",
+                log: bluetoothLog,
+                type: .error,
+                peripheral.identifier.description,
+                peripheral.name ?? "",
+                service.description,
+                error as CVarArg
+            )
+
+        } else {
+            os_log(
+                "Peripheral (uuid: %@ name: %@) did discover characteristics for service: %@",
+                log: bluetoothLog,
+                peripheral.identifier.description,
+                peripheral.name ?? "",
+                service.description
+            )
+        }
+
+        guard error == nil, let services = peripheral.services else {
+            cancelConnectionIfNeeded(for: peripheral)
+            return
+        }
+        let servicesWithCharacteristicsToDiscover = services.filter {
+            $0.characteristics == nil
+        }
+        if servicesWithCharacteristicsToDiscover.count == 0 {
+            startTransfers(for: peripheral)
+        }
+    }
+
+    private func shouldReadConfigurations(from peripheral: CBPeripheral) -> Bool {
+        return self.peripheralsToReadConfigurationsFrom.contains(peripheral)
+    }
+
+    private func startTransfers(for peripheral: CBPeripheral) {
+        guard let services = peripheral.services else {
+            self.cancelConnectionIfNeeded(for: peripheral)
+            return
+        }
+        services.forEach { service in
+            peripheralShared(peripheral, didDiscoverCharacteristicsFor: service, error: nil)
+        }
+    }
+
+    func peripheralShared(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService,
+                          error: Error?) {
+        guard error == nil else {
+            cancelConnectionIfNeeded(for: peripheral)
+            return
+        }
+
+        // Read configuration, if needed
+        if let configurationCharacteristic = service.characteristics?.first(where: {
+            $0.uuid == CBUUID(string: Uuids.characteristic.uuidString)
+        }), shouldReadConfigurations(from: peripheral) {
+
+            if !readingConfigurationCharacteristics.contains(configurationCharacteristic) {
+                readingConfigurationCharacteristics.insert(configurationCharacteristic)
+                peripheral.readValue(for: configurationCharacteristic)
+
+                os_log(
+                    "Peripheral (uuid: %@ name: %@) reading value for characteristic: %@ for service: %@",
+                    log: bluetoothLog,
+                    peripheral.identifier.description,
+                    peripheral.name ?? "",
+                    configurationCharacteristic.description,
+                    service.description
+                )
+            }
+        }
+    }
+
+    func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        if let error = error {
+            os_log(
+                "Peripheral (uuid: %@ name: '%@') did update value for characteristic: %@ for service: %@ error: %@",
+                log: bluetoothLog,
+                type: .error,
+                peripheral.identifier.description,
+                peripheral.name ?? "",
+                characteristic.description,
+                characteristic.service.description,
+                error as CVarArg
+            )
+        }
+        else {
+            os_log(
+                "Peripheral (uuid: %@ name: '%@') did update value: %{iec-bytes}d for characteristic: %@ for service: %@",
+                log: bluetoothLog,
+                peripheral.identifier.description,
+                peripheral.name ?? "",
+                characteristic.value?.count ?? 0,
+                characteristic.description,
+                characteristic.service.description
+            )
+        }
+        readingConfigurationCharacteristics.remove(characteristic)
+
+        do {
+            peripheralsToReadConfigurationsFrom.remove(peripheral)
+            guard error == nil else {
+                cancelConnectionIfNeeded(for: peripheral)
+                return
+            }
+            guard let value = characteristic.value else {
+                throw CBATTError(.invalidPdu)
+            }
+            let identifier = try UUID(dataRepresentation: value)
+            addNewContactEvent(with: identifier)
+            cancelConnectionIfNeeded(for: peripheral)
+
+        } catch {
+            cancelConnectionIfNeeded(for: peripheral)
+            os_log(
+                "Processing value failed: %@",
+                log: bluetoothLog,
+                type: .error,
+                error as CVarArg
+            )
+        }
+    }
+
+    func peripheral(
+        _ peripheral: CBPeripheral,
+        didModifyServices invalidatedServices: [CBService]
+    ) {
+        os_log(
+            "Peripheral (uuid=%@ name='%@') did modify services=%@",
+            log: bluetoothLog,
+            peripheral.identifier.description,
+            peripheral.name ?? "",
+            invalidatedServices
+        )
+
+        if invalidatedServices.contains(where: {
+            $0.uuid == CBUUID(string: Uuids.service.uuidString)
+        }) {
+            peripheralsToReadConfigurationsFrom.insert(peripheral)
+            cancelConnectionIfNeeded(for: peripheral)
+        }
+    }
+}
+
+
+extension TimeInterval {
+    public static let peripheralConnectingTimeout: TimeInterval = 8
+}

--- a/ios/Central.swift
+++ b/ios/Central.swift
@@ -1,3 +1,5 @@
+// Refactored from https://github.com/covid19risk/covidwatch-ios/blob/master/COVIDWatch%20iOS/Bluetooth/BluetoothController.swift
+
 import Foundation
 import CoreBluetooth
 import os.log

--- a/ios/Central.swift
+++ b/ios/Central.swift
@@ -56,7 +56,7 @@ class Central: NSObject {
                 CBCentralManagerScanOptionAllowDuplicatesKey : NSNumber(booleanLiteral: true)
             ]
         )
-        os_log("Central manager scanning for peripherals with services=%@", log: bluetoothLog, services ?? [])
+        os_log("Central manager scanning for peripherals with services=%@", log: bleCentralLog, services ?? [])
     }
 
     private func servicesToScan() -> [CBUUID]? {
@@ -91,7 +91,7 @@ class Central: NSObject {
 
             os_log(
                 "Central manager connecting peripheral (uuid: %@ name: %@)",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 peripheral.identifier.description,
                 peripheral.name ?? ""
             )
@@ -131,7 +131,7 @@ class Central: NSObject {
             if peripheral.state != .connected {
                 os_log(
                     "Connecting did time out for peripheral (uuid=%@ name='%@')",
-                    log: bluetoothLog,
+                    log: bleCentralLog,
                     peripheral.identifier.description,
                     peripheral.name ?? ""
                 )
@@ -154,7 +154,7 @@ class Central: NSObject {
             centralManager?.cancelPeripheralConnection(peripheral)
             os_log(
                 "Central manager cancelled peripheral (uuid=%@ name='%@') connection",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 peripheral.identifier.description,
                 peripheral.name ?? ""
             )
@@ -180,7 +180,7 @@ class Central: NSObject {
 extension Central: CBCentralManagerDelegate {
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        os_log("Central manager did update state: %d", log: bluetoothLog, central.state.rawValue)
+        os_log("Central manager did update state: %d", log: bleCentralLog, central.state.rawValue)
         if central.state == .poweredOn {
             startScan()
             centralManager.scanForPeripherals(withServices: nil)
@@ -197,12 +197,12 @@ extension Central: CBCentralManagerDelegate {
 
         delegate?.onDiscovered(peripheral: peripheral)
 
-        os_log("advertisementData: %@", log: bluetoothLog, advertisementData)
+//        os_log("advertisementData: %@", log: bleCentralLog, advertisementData)
 
         if !discoveredPeripherals.contains(peripheral) {
             os_log(
                 "Central manager did discover new peripheral (uuid: %@ name: %@) RSSI: %d",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 peripheral.identifier.description,
                 peripheral.name ?? "",
                 RSSI.intValue
@@ -217,7 +217,7 @@ extension Central: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         os_log(
             "Central manager did connect peripheral (uuid: %@ name: %@)",
-            log: bluetoothLog,
+            log: bleCentralLog,
             peripheral.identifier.description,
             peripheral.name ?? ""
         )
@@ -250,7 +250,7 @@ extension Central: CBCentralManagerDelegate {
 
             os_log(
                 "Central manager periferal: (uuid: %@ name: %@) discovering services: %@",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 peripheral.identifier.description,
                 peripheral.name ?? "",
                 services
@@ -296,8 +296,8 @@ extension Central: CBCentralManagerDelegate {
                 peripheral.discoverCharacteristics(characteristics, for: service)
 
                 os_log(
-                    "Peripheral (uuid: %@ name: %@) discovering characteristics=%@ for service: %@",
-                    log: bluetoothLog,
+                    "Peripheral (uuid: %@ name: %@) discovering characteristics: %@ for service: %@",
+                    log: bleCentralLog,
                     peripheral.identifier.description,
                     peripheral.name ?? "",
                     characteristics.description,
@@ -316,7 +316,7 @@ extension Central: CBPeripheralDelegate {
         guard let services = peripheral.services else { return }
 
         for service in services {
-          os_log("service: %@", log: bluetoothLog, service)
+          os_log("service: %@", log: bleCentralLog, service)
         }
 
         peripheralShared(peripheral, didDiscoverServices: error)
@@ -330,7 +330,7 @@ extension Central: CBPeripheralDelegate {
         if let error = error {
             os_log(
                 "Peripheral (uuid: %@ name: %@) did discover characteristics for service: %@ error: %@",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 type: .error,
                 peripheral.identifier.description,
                 peripheral.name ?? "",
@@ -341,7 +341,7 @@ extension Central: CBPeripheralDelegate {
         } else {
             os_log(
                 "Peripheral (uuid: %@ name: %@) did discover characteristics for service: %@",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 peripheral.identifier.description,
                 peripheral.name ?? "",
                 service.description
@@ -392,7 +392,7 @@ extension Central: CBPeripheralDelegate {
 
                 os_log(
                     "Peripheral (uuid: %@ name: %@) reading value for characteristic: %@ for service: %@",
-                    log: bluetoothLog,
+                    log: bleCentralLog,
                     peripheral.identifier.description,
                     peripheral.name ?? "",
                     configurationCharacteristic.description,
@@ -410,7 +410,7 @@ extension Central: CBPeripheralDelegate {
         if let error = error {
             os_log(
                 "Peripheral (uuid: %@ name: '%@') did update value for characteristic: %@ for service: %@ error: %@",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 type: .error,
                 peripheral.identifier.description,
                 peripheral.name ?? "",
@@ -422,7 +422,7 @@ extension Central: CBPeripheralDelegate {
         else {
             os_log(
                 "Peripheral (uuid: %@ name: '%@') did update value: %{iec-bytes}d for characteristic: %@ for service: %@",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 peripheral.identifier.description,
                 peripheral.name ?? "",
                 characteristic.value?.count ?? 0,
@@ -449,7 +449,7 @@ extension Central: CBPeripheralDelegate {
             cancelConnectionIfNeeded(for: peripheral)
             os_log(
                 "Processing value failed: %@",
-                log: bluetoothLog,
+                log: bleCentralLog,
                 type: .error,
                 error as CVarArg
             )
@@ -462,7 +462,7 @@ extension Central: CBPeripheralDelegate {
     ) {
         os_log(
             "Peripheral (uuid=%@ name='%@') did modify services=%@",
-            log: bluetoothLog,
+            log: bleCentralLog,
             peripheral.identifier.description,
             peripheral.name ?? "",
             invalidatedServices

--- a/ios/CoEpi.xcodeproj/project.pbxproj
+++ b/ios/CoEpi.xcodeproj/project.pbxproj
@@ -20,11 +20,12 @@
 		5EE555DC1AAEDC6966CE5E97 /* libPods-CoEpi-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DD4CE753B8DE9B43713D7F4 /* libPods-CoEpi-tvOSTests.a */; };
 		849E003C24152F3E007DB872 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E003B24152F3E007DB872 /* Bridge.swift */; };
 		849E003E24152F8D007DB872 /* Bridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 849E003D24152F8D007DB872 /* Bridge.m */; };
-		84A05AA1241551A500843354 /* BLEDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A05AA0241551A500843354 /* BLEDiscovery.swift */; };
+		84A05AA1241551A500843354 /* Central.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A05AA0241551A500843354 /* Central.swift */; };
 		84A64ECD2419785B003BEC25 /* Peripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A64ECC2419785B003BEC25 /* Peripheral.swift */; };
 		84E97874241E877C00760E2A /* DataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E97873241E877C00760E2A /* DataRepresentable.swift */; };
 		84E97876241E87F000760E2A /* Types+DataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E97875241E87F000760E2A /* Types+DataRepresentable.swift */; };
 		84E9787A241ECE1C00760E2A /* LogSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E97879241ECE1C00760E2A /* LogSettings.swift */; };
+		84E97878241E905C00760E2A /* uuids.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E97877241E905C00760E2A /* uuids.swift */; };
 		8D4826396D6ED806B1AAB240 /* libPods-CoEpi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37DE2CF01D1C0EF799E7168C /* libPods-CoEpi.a */; };
 		E64FBE63A6DC4B90A79EB154 /* libPods-CoEpi-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA95D893CE66627576115A1F /* libPods-CoEpi-tvOS.a */; };
 /* End PBXBuildFile section */
@@ -67,11 +68,12 @@
 		849E003A24152F3E007DB872 /* CoEpi-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CoEpi-Bridging-Header.h"; sourceTree = "<group>"; };
 		849E003B24152F3E007DB872 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
 		849E003D24152F8D007DB872 /* Bridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Bridge.m; sourceTree = "<group>"; };
-		84A05AA0241551A500843354 /* BLEDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEDiscovery.swift; sourceTree = "<group>"; };
+		84A05AA0241551A500843354 /* Central.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Central.swift; sourceTree = "<group>"; };
 		84A64ECC2419785B003BEC25 /* Peripheral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peripheral.swift; sourceTree = "<group>"; };
 		84E97873241E877C00760E2A /* DataRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataRepresentable.swift; sourceTree = "<group>"; };
 		84E97875241E87F000760E2A /* Types+DataRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Types+DataRepresentable.swift"; sourceTree = "<group>"; };
 		84E97879241ECE1C00760E2A /* LogSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSettings.swift; sourceTree = "<group>"; };
+		84E97877241E905C00760E2A /* uuids.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = uuids.swift; sourceTree = "<group>"; };
 		9AE11219F5F11E1967C28546 /* Pods-CoEpi.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpi.debug.xcconfig"; path = "Target Support Files/Pods-CoEpi/Pods-CoEpi.debug.xcconfig"; sourceTree = "<group>"; };
 		9BC35E1A6ECA77DF53A54AD5 /* Pods-CoEpi-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpi-tvOS.release.xcconfig"; path = "Target Support Files/Pods-CoEpi-tvOS/Pods-CoEpi-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		9E04946EADA216F7C3A9A69D /* Pods-CoEpiTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpiTests.release.xcconfig"; path = "Target Support Files/Pods-CoEpiTests/Pods-CoEpiTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -150,11 +152,12 @@
 				849E003B24152F3E007DB872 /* Bridge.swift */,
 				849E003A24152F3E007DB872 /* CoEpi-Bridging-Header.h */,
 				849E003D24152F8D007DB872 /* Bridge.m */,
-				84A05AA0241551A500843354 /* BLEDiscovery.swift */,
+				84A05AA0241551A500843354 /* Central.swift */,
 				84A64ECC2419785B003BEC25 /* Peripheral.swift */,
 				84E97873241E877C00760E2A /* DataRepresentable.swift */,
 				84E97875241E87F000760E2A /* Types+DataRepresentable.swift */,
 				84E97879241ECE1C00760E2A /* LogSettings.swift */,
+				84E97877241E905C00760E2A /* uuids.swift */,
 			);
 			name = CoEpi;
 			sourceTree = "<group>";
@@ -317,7 +320,9 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = 37QAPDY2PR;
 						LastSwiftMigration = 1130;
+						ProvisioningStyle = Manual;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -560,9 +565,10 @@
 				849E003E24152F8D007DB872 /* Bridge.m in Sources */,
 				84E9787A241ECE1C00760E2A /* LogSettings.swift in Sources */,
 				84E97876241E87F000760E2A /* Types+DataRepresentable.swift in Sources */,
+				84E97878241E905C00760E2A /* uuids.swift in Sources */,
 				84A64ECD2419785B003BEC25 /* Peripheral.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
-				84A05AA1241551A500843354 /* BLEDiscovery.swift in Sources */,
+				84A05AA1241551A500843354 /* Central.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				849E003C24152F3E007DB872 /* Bridge.swift in Sources */,
 			);

--- a/ios/CoEpi.xcodeproj/project.pbxproj
+++ b/ios/CoEpi.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		849E003E24152F8D007DB872 /* Bridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 849E003D24152F8D007DB872 /* Bridge.m */; };
 		84A05AA1241551A500843354 /* BLEDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A05AA0241551A500843354 /* BLEDiscovery.swift */; };
 		84A64ECD2419785B003BEC25 /* Peripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A64ECC2419785B003BEC25 /* Peripheral.swift */; };
+		84E97874241E877C00760E2A /* DataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E97873241E877C00760E2A /* DataRepresentable.swift */; };
+		84E97876241E87F000760E2A /* Types+DataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E97875241E87F000760E2A /* Types+DataRepresentable.swift */; };
+		84E9787A241ECE1C00760E2A /* LogSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E97879241ECE1C00760E2A /* LogSettings.swift */; };
 		8D4826396D6ED806B1AAB240 /* libPods-CoEpi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37DE2CF01D1C0EF799E7168C /* libPods-CoEpi.a */; };
 		E64FBE63A6DC4B90A79EB154 /* libPods-CoEpi-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA95D893CE66627576115A1F /* libPods-CoEpi-tvOS.a */; };
 /* End PBXBuildFile section */
@@ -66,6 +69,9 @@
 		849E003D24152F8D007DB872 /* Bridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Bridge.m; sourceTree = "<group>"; };
 		84A05AA0241551A500843354 /* BLEDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEDiscovery.swift; sourceTree = "<group>"; };
 		84A64ECC2419785B003BEC25 /* Peripheral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peripheral.swift; sourceTree = "<group>"; };
+		84E97873241E877C00760E2A /* DataRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataRepresentable.swift; sourceTree = "<group>"; };
+		84E97875241E87F000760E2A /* Types+DataRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Types+DataRepresentable.swift"; sourceTree = "<group>"; };
+		84E97879241ECE1C00760E2A /* LogSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSettings.swift; sourceTree = "<group>"; };
 		9AE11219F5F11E1967C28546 /* Pods-CoEpi.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpi.debug.xcconfig"; path = "Target Support Files/Pods-CoEpi/Pods-CoEpi.debug.xcconfig"; sourceTree = "<group>"; };
 		9BC35E1A6ECA77DF53A54AD5 /* Pods-CoEpi-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpi-tvOS.release.xcconfig"; path = "Target Support Files/Pods-CoEpi-tvOS/Pods-CoEpi-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		9E04946EADA216F7C3A9A69D /* Pods-CoEpiTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoEpiTests.release.xcconfig"; path = "Target Support Files/Pods-CoEpiTests/Pods-CoEpiTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -146,6 +152,9 @@
 				849E003D24152F8D007DB872 /* Bridge.m */,
 				84A05AA0241551A500843354 /* BLEDiscovery.swift */,
 				84A64ECC2419785B003BEC25 /* Peripheral.swift */,
+				84E97873241E877C00760E2A /* DataRepresentable.swift */,
+				84E97875241E87F000760E2A /* Types+DataRepresentable.swift */,
+				84E97879241ECE1C00760E2A /* LogSettings.swift */,
 			);
 			name = CoEpi;
 			sourceTree = "<group>";
@@ -547,7 +556,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84E97874241E877C00760E2A /* DataRepresentable.swift in Sources */,
 				849E003E24152F8D007DB872 /* Bridge.m in Sources */,
+				84E9787A241ECE1C00760E2A /* LogSettings.swift in Sources */,
+				84E97876241E87F000760E2A /* Types+DataRepresentable.swift in Sources */,
 				84A64ECD2419785B003BEC25 /* Peripheral.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				84A05AA1241551A500843354 /* BLEDiscovery.swift in Sources */,
@@ -665,6 +677,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 37QAPDY2PR;
 				INFOPLIST_FILE = CoEpi/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -691,6 +704,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 37QAPDY2PR;
 				INFOPLIST_FILE = CoEpi/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/ios/DataRepresentable.swift
+++ b/ios/DataRepresentable.swift
@@ -1,0 +1,39 @@
+// Src: https://github.com/zssz/BerkananFoundation
+//
+// Copyright © 2019 IZE Ltd. and the project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information.
+//
+
+import Foundation
+
+/// A type that can convert itself into and out of a little endian byte buffer.
+public protocol DataRepresentable {
+
+  /// Initialize an instance from a little endian byte buffer.
+  ///
+  /// - Parameter dataRepresentation: A little endian byte buffer.
+  init<D>(dataRepresentation: D) throws where D: ContiguousBytes
+
+  /// Returns a little endian byte buffer.
+  var dataRepresentation: Data { get }
+}
+
+extension DataRepresentable {
+
+  public init<D>(dataRepresentation: D) throws where D: ContiguousBytes {
+    self = try dataRepresentation.withUnsafeBytes {
+      guard $0.count == MemoryLayout<Self>.size,
+        let baseAddress = $0.baseAddress else {
+          throw CocoaError(.coderInvalidValue)
+      }
+      return baseAddress.bindMemory(to: Self.self, capacity: 1).pointee
+    }
+  }
+
+  public var dataRepresentation: Data {
+    var value = self
+    return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+  }
+}

--- a/ios/LogSettings.swift
+++ b/ios/LogSettings.swift
@@ -1,0 +1,7 @@
+import Foundation
+import os.log
+
+let bluetoothLog = OSLog(
+    subsystem: Bundle.main.bundleIdentifier!,
+    category: "Bluetooth"
+)

--- a/ios/LogSettings.swift
+++ b/ios/LogSettings.swift
@@ -1,7 +1,12 @@
 import Foundation
 import os.log
 
-let bluetoothLog = OSLog(
+let bleCentralLog = OSLog(
     subsystem: Bundle.main.bundleIdentifier!,
-    category: "Bluetooth"
+    category: "BLECentral"
+)
+
+let blePeripheralLog = OSLog(
+    subsystem: Bundle.main.bundleIdentifier!,
+    category: "BLEPeripheral"
 )

--- a/ios/Peripheral.swift
+++ b/ios/Peripheral.swift
@@ -13,7 +13,7 @@ class Peripheral: NSObject {
     private var peripheralManager: CBPeripheralManager!
 
     private let serviceUuid: CBUUID = CBUUID(nsuuid: Uuids.service)
-    private let characteristicUuid: CBUUID = CBUUID(nsuuid: Uuids.service)
+    private let characteristicUuid: CBUUID = CBUUID(nsuuid: Uuids.characteristic)
 
     init(delegate: PeripheralDelegate) {
         self.delegate = delegate

--- a/ios/Peripheral.swift
+++ b/ios/Peripheral.swift
@@ -45,7 +45,7 @@ class Peripheral: NSObject {
         )
         service.characteristics = [characteristic]
 
-        os_log("Peripheral manager adding service: %@", log: bluetoothLog, service)
+        os_log("Peripheral manager adding service: %@", log: blePeripheralLog, service)
 
         return service
     }
@@ -79,18 +79,17 @@ extension Peripheral: CBPeripheralManagerDelegate {
 
     func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
         if let error = error {
-            os_log("Advertising error: %@", log: bluetoothLog, type: .error, error.localizedDescription)
+            os_log("Advertising error: %@", log: blePeripheralLog, type: .error, error.localizedDescription)
         } else {
-            os_log("Peripheral manager did add service=%@", log: bluetoothLog, service)
+            os_log("Peripheral manager did add service: %@", log: blePeripheralLog, service)
         }
-
     }
 
     func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
         if let error = error {
-            os_log("Advertising error: %@", log: bluetoothLog, type: .error, error.localizedDescription)
+            os_log("Advertising error: %@", log: blePeripheralLog, type: .error, error.localizedDescription)
         } else {
-            os_log("Peripheral manager starting advertising", log: bluetoothLog)
+            os_log("Peripheral manager starting advertising", log: blePeripheralLog)
         }
     }
 

--- a/ios/Peripheral.swift
+++ b/ios/Peripheral.swift
@@ -1,16 +1,22 @@
 import Foundation
 import CoreBluetooth
+import os.log
+
+protocol PeripheralDelegate: class {
+    func onPeripheralStateChange(description: String)
+    func onNewContact(_ contact: Contact)
+}
 
 class Peripheral: NSObject {
-    private let onStateChange: ((String) -> Void)?
+    private weak var delegate: PeripheralDelegate?
 
     private var peripheralManager: CBPeripheralManager!
 
     private let serviceUuid = CBUUID(nsuuid: UUID(uuidString: "BC908F39-52DB-416F-A97E-6EAC29F59CA8")!)
     private let characteristicUuid = CBUUID(nsuuid: UUID(uuidString: "2ac35b0b-00b5-4af2-a50e-8412bcb94285")!)
 
-    init(onStateChange: @escaping ((String) -> Void)) {
-        self.onStateChange = onStateChange
+    init(delegate: PeripheralDelegate) {
+        self.delegate = delegate
 
         super.init()
         peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
@@ -20,16 +26,12 @@ class Peripheral: NSObject {
         let service = createService()
         peripheralManager.add(service)
 
-        print("Will start advertising")
-
         peripheralManager.startAdvertising([
             // NOTE/TODO this identifier is supposed to show directly in discovery. It doesn't. Service is listed in iPhone peripheral.
             CBAdvertisementDataLocalNameKey : "BLEPeripheralApp",
 
             CBAdvertisementDataServiceUUIDsKey : [serviceUuid]
         ])
-
-        print("Started advertising")
     }
 
     private func createService() -> CBMutableService {
@@ -38,10 +40,12 @@ class Peripheral: NSObject {
         let characteristic = CBMutableCharacteristic(
             type: characteristicUuid,
             properties: [.read],
-            value: "AD34E".data(using: .utf8),
+            value: nil,
             permissions: [.readable]
         )
         service.characteristics = [characteristic]
+
+        os_log("Peripheral manager adding service: %@", log: bluetoothLog, service)
 
         return service
     }
@@ -65,19 +69,54 @@ extension Peripheral: CBPeripheralManagerDelegate {
             report(state: "poweredOn")
             startAdvertising()
         @unknown default:
-            print("Peripheral state: unknown")
+            os_log("Peripheral state: unknown")
         }
     }
 
     private func report(state: String) {
-        onStateChange?("Peripheral state: \(state)")
+        delegate?.onPeripheralStateChange(description: state)
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
+        if let error = error {
+            os_log("Advertising error: %@", log: bluetoothLog, type: .error, error.localizedDescription)
+        } else {
+            os_log("Peripheral manager did add service=%@", log: bluetoothLog, service)
+        }
+
     }
 
     func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
-        if error == nil {
-            NSLog("Advertising ok")
+        if let error = error {
+            os_log("Advertising error: %@", log: bluetoothLog, type: .error, error.localizedDescription)
         } else {
-            NSLog("Advertising error: \(String(describing: error))")
+            os_log("Peripheral manager starting advertising", log: bluetoothLog)
         }
     }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
+        os_log("Peripheral manager did receive read request: %@", request.description)
+
+        let identifier = UUID()
+        addNewContactEvent(with: identifier)
+        request.value = identifier.dataRepresentation
+        peripheral.respond(to: request, withResult: .success)
+
+        os_log("Peripheral manager did respond to read request with result: %d", CBATTError.success.rawValue)
+    }
+
+    private func addNewContactEvent(with identifier: UUID) {
+        delegate?.onNewContact(Contact(
+            identifier: identifier,
+            timestamp: Date(),
+            // TODO preference, from React Native
+            isPotentiallyInfectious: true
+        ))
+    }
+}
+
+struct Contact {
+    let identifier: UUID
+    let timestamp: Date
+    let isPotentiallyInfectious: Bool
 }

--- a/ios/Peripheral.swift
+++ b/ios/Peripheral.swift
@@ -4,7 +4,7 @@ import os.log
 
 protocol PeripheralDelegate: class {
     func onPeripheralStateChange(description: String)
-    func onNewContact(_ contact: Contact)
+    func onPeripheralContact(_ contact: Contact)
 }
 
 class Peripheral: NSObject {
@@ -12,8 +12,8 @@ class Peripheral: NSObject {
 
     private var peripheralManager: CBPeripheralManager!
 
-    private let serviceUuid = CBUUID(nsuuid: UUID(uuidString: "BC908F39-52DB-416F-A97E-6EAC29F59CA8")!)
-    private let characteristicUuid = CBUUID(nsuuid: UUID(uuidString: "2ac35b0b-00b5-4af2-a50e-8412bcb94285")!)
+    private let serviceUuid: CBUUID = CBUUID(nsuuid: Uuids.service)
+    private let characteristicUuid: CBUUID = CBUUID(nsuuid: Uuids.service)
 
     init(delegate: PeripheralDelegate) {
         self.delegate = delegate
@@ -106,7 +106,7 @@ extension Peripheral: CBPeripheralManagerDelegate {
     }
 
     private func addNewContactEvent(with identifier: UUID) {
-        delegate?.onNewContact(Contact(
+        delegate?.onPeripheralContact(Contact(
             identifier: identifier,
             timestamp: Date(),
             // TODO preference, from React Native

--- a/ios/Types+DataRepresentable.swift
+++ b/ios/Types+DataRepresentable.swift
@@ -1,0 +1,14 @@
+// Src: https://github.com/zssz/BerkananFoundation
+//
+// Copyright © 2019 IZE Ltd. and the project authors
+// Licensed under MIT License
+//
+// See LICENSE.txt for license information.
+//
+
+import Foundation
+
+extension UInt16: DataRepresentable {}
+extension UInt32: DataRepresentable {}
+extension UInt64: DataRepresentable {}
+extension UUID: DataRepresentable {}

--- a/ios/uuids.swift
+++ b/ios/uuids.swift
@@ -1,0 +1,4 @@
+struct Uuids {
+    static let service: UUID = UUID(uuidString: "BC908F39-52DB-416F-A97E-6EAC29F59CA8")!
+    static let characteristic: UUID = UUID(uuidString: "2ac35b0b-00b5-4af2-a50e-8412bcb94285")!
+}


### PR DESCRIPTION
Integrated the iOS BLE peripheral and central functionality.

We use for now the same payload (a "contact" with a `isPotentiallyInfectious` flag, which is hardcoded to `true`, as we will do the business login in RN). This will probably change.

@scottleibrand I leave it to you how to credit the original project. I refactored it. The functionality is largely the same. I didn't touch the parts that are not related with BLE.

I'll migrate the functionality to improve the background handling in a new PR.

You can test using 2 devices.
![49418](https://user-images.githubusercontent.com/1381744/76712306-bf52ba00-6717-11ea-8810-52a3cce1abd6.jpg)
