### PR TITLE
Ios duplicated event

### DIFF
--- a/ios/Central.swift
+++ b/ios/Central.swift
@@ -313,6 +313,15 @@ extension Central: CBCentralManagerDelegate {
 
         discoverServices(for: peripheral)
     }
+    
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        os_log(
+                  "Central manager did disconnect peripheral (uuid: %@ name: %@)",
+                  log: bleCentralLog,
+                  peripheral.identifier.description,
+                  peripheral.name ?? ""
+              )
+    }
 
     private func discoverServices(for peripheral: CBPeripheral) {
         guard

--- a/ios/Central.swift
+++ b/ios/Central.swift
@@ -270,8 +270,6 @@ extension Central: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
                         advertisementData: [String: Any], rssi RSSI: NSNumber) {
 
-        delegate?.onDiscovered(peripheral: peripheral)
-
         self.peripheral = peripheral
 //        centralManager.stopScan()
 

--- a/ios/Central.swift
+++ b/ios/Central.swift
@@ -264,7 +264,6 @@ extension Central: CBCentralManagerDelegate {
         os_log("Central manager did update state: %d", log: bleCentralLog, central.state.rawValue)
         if central.state == .poweredOn {
             startScan()
-            centralManager.scanForPeripherals(withServices: nil)
         }
     }
 


### PR DESCRIPTION
"If the central manager is actively scanning with one set of parameters and it receives another set to scan, the new parameters override the previous set."
https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1518986-scanforperipherals